### PR TITLE
Fix init tracker

### DIFF
--- a/src/data/Monster.java
+++ b/src/data/Monster.java
@@ -223,4 +223,43 @@ public class Monster implements Serializable
 	        return 0;
 	    }
 	}
+	
+	@Override
+	public boolean equals(Object obj) {
+	    if (this == obj) return true;
+	    if (obj == null || getClass() != obj.getClass()) return false;
+
+	    Monster other = (Monster) obj;
+
+	    return lActNum == other.lActNum &&
+	           lActBns == other.lActBns &&
+	           Double.compare(other.cr, cr) == 0 &&
+	           custom == other.custom &&
+	           java.util.Objects.equals(name, other.name) &&
+	           java.util.Objects.equals(typeSizeAlignment, other.typeSizeAlignment) &&
+	           java.util.Objects.equals(ac, other.ac) &&
+	           java.util.Objects.equals(init, other.init) &&
+	           java.util.Objects.equals(hp, other.hp) &&
+	           java.util.Objects.equals(speed, other.speed) &&
+	           java.util.Objects.equals(senses, other.senses) &&
+	           java.util.Objects.equals(languages, other.languages) &&
+	           java.util.Objects.equals(dmgVul, other.dmgVul) &&
+	           java.util.Objects.equals(dmgRes, other.dmgRes) &&
+	           java.util.Objects.equals(immune, other.immune) &&
+	           java.util.Arrays.equals(stats, other.stats) &&
+	           java.util.Arrays.equals(saves, other.saves) &&
+	           java.util.Objects.equals(skills, other.skills) &&
+	           java.util.Objects.equals(tags, other.tags) &&
+	           source == other.source;
+	}
+
+	@Override
+	public int hashCode() {
+	    int result = java.util.Objects.hash(name, typeSizeAlignment, ac, init, hp, speed, senses, languages,
+	                                        dmgVul, dmgRes, immune, lActNum, lActBns, skills, cr, tags, custom, source);
+	    result = 31 * result + java.util.Arrays.hashCode(stats);
+	    result = 31 * result + java.util.Arrays.hashCode(saves);
+	    return result;
+	}
+
 }

--- a/src/gui/builder_internals/MonsterBuilderIFrame.java
+++ b/src/gui/builder_internals/MonsterBuilderIFrame.java
@@ -1115,10 +1115,7 @@ public class MonsterBuilderIFrame extends JInternalFrame {
 	}
 
 	private void LoadMonsters(Map<String, Monster> mIn) {
-		monstMap = new HashMap<String, Monster>();
-		for (String s : mIn.keySet())
-			monstMap.put(s, mIn.get(s));
-
+		monstMap = new HashMap<String, Monster>(mIn);
 		BuildMonstListPane();
 	}
 	

--- a/src/gui/builder_internals/QuickInsertBuilderIFrame.java
+++ b/src/gui/builder_internals/QuickInsertBuilderIFrame.java
@@ -215,23 +215,7 @@ public class QuickInsertBuilderIFrame extends JInternalFrame
 //		oos.close();
 //	}
 
-
-	@SuppressWarnings("unchecked")
 	private void LoadInserts() {
-		File inFile = new File(DataContainer.INSERT_FILE_NAME);
-		
-		if(inFile.exists()) {
-			try {
-				ObjectInputStream ois = new ObjectInputStream(new FileInputStream(inFile));
-				inMap = (HashMap<String, StyledDocument>) ois.readObject();
-				ois.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			} catch (ClassNotFoundException e) {
-				e.printStackTrace();
-			}
-		}else {
-			inMap = new HashMap<String, StyledDocument>();
-		}
+		inMap = new HashMap<String, StyledDocument>(data.getInserts());
 	}
 }

--- a/src/gui/builder_internals/SpellBuilderIFrame.java
+++ b/src/gui/builder_internals/SpellBuilderIFrame.java
@@ -200,26 +200,7 @@ public class SpellBuilderIFrame extends JInternalFrame {
 	}
 
 	public void ReadSpellList() {
-		spellMap = new HashMap<String, Spell>();
-		File spellFile = new File(DataContainer.SPELLS_FILE_NAME);
-
-		if (spellFile.exists()) {
-			try {
-				ObjectInputStream ois = new ObjectInputStream(new FileInputStream(spellFile));
-				while (true) {
-					try {
-						Spell obj = (Spell) ois.readObject();
-						spellMap.put(obj.name, obj);
-					} catch (EOFException | ClassNotFoundException e) {
-						// End of file reached
-						break;
-					}
-				}
-				ois.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
+		spellMap = new HashMap<String, Spell>(data.getSpells());
 	}
 	
 	private void LoadSpell(String key) {

--- a/src/gui/builder_internals/SpellBuilderIFrame.java
+++ b/src/gui/builder_internals/SpellBuilderIFrame.java
@@ -208,7 +208,7 @@ public class SpellBuilderIFrame extends JInternalFrame {
 			editor.close();
 			centerPane.remove(editor);
 			editor = new RichEditor(data);
-			editor.LoadDocument(data.getSpells().get(keyVal).spellDoc);
+			editor.LoadDocument(data.getSpells().get(keyVal).spellDoc); 
 			centerPane.add(editor, BorderLayout.CENTER);
 			spellNameField.setText(keyVal);
 			


### PR DESCRIPTION
Updates and fixes issues in the Initiative Tracker and builders

Builders now create maps to edit based on the Maps from data.

Initiative Tracker now uses unique IDs on each of the actors in order to properly track and remove them from the initiative order.