### PR TITLE
Notes and Spell Fix

### DIFF
--- a/src/gui/SpellIFrame.java
+++ b/src/gui/SpellIFrame.java
@@ -223,7 +223,7 @@ public class SpellIFrame extends JInternalFrame implements ContentTab, DataChang
 		cardPane.setLayout(new CardLayout());
 		cPane.add(cardPane, BorderLayout.CENTER);
 		
-		JLabel noLoad = new JLabel("Np Spells Selected");
+		JLabel noLoad = new JLabel("No Spells Selected");
 		StyleContainer.SetFontHeader(noLoad);
 		cardPane.add(noLoad, "noload");
 		

--- a/src/gui/campaign/NotesIFrame.java
+++ b/src/gui/campaign/NotesIFrame.java
@@ -226,9 +226,13 @@ public class NotesIFrame extends JInternalFrame
 	
 	private void LoadEditorConf(String key) {
 		if(noteTitle.getText().length() > 0 || edit.getStyledDocument().getLength() > 0) {
-			int loadConf = JOptionPane.showConfirmDialog(edit, "Would you like to load, you will lose any unsaved work",
-					"Load Confirmation", JOptionPane.YES_NO_OPTION);
-			if(loadConf == JOptionPane.YES_OPTION) {
+			if(editChck.isSelected()) {
+				int loadConf = JOptionPane.showConfirmDialog(edit, "Would you like to load, you will lose any unsaved work",
+						"Load Confirmation", JOptionPane.YES_NO_OPTION);
+				if(loadConf == JOptionPane.YES_OPTION) {
+					LoadEditor(key);
+				}
+			}else{
 				LoadEditor(key);
 			}
 		}else {


### PR DESCRIPTION
Fix spells not loaded displaying as Np Spell Loaded instead of No.

Updated Notes frame to only ask to confirm when editing.